### PR TITLE
fix construction of UnixEp in createEp()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 option(BUILD_UNIT_TESTS "Build unit tests" ON)
 
+find_package(Threads REQUIRED)
+
 include(FetchContent)
 
 FetchContent_Declare(

--- a/comm_channel.hpp
+++ b/comm_channel.hpp
@@ -184,7 +184,7 @@ private:
 
   static UnixEp createEp(std::string_view sv) requires(Mode == ChannelMode::Unix) {
     std::remove(std::string(sv).c_str());
-    return UnixEp(sv);
+    return UnixEp(std::string(sv));
   }
 
   asio::steady_timer timer_;

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -9,4 +9,5 @@ foreach(test_src ${TEST_SOURCES})
     get_filename_component(test_name ${test_src} NAME_WE)
 
     add_executable(${test_name} ${test_src})
+    target_link_libraries(${test_name} PRIVATE Threads::Threads)
 endforeach()


### PR DESCRIPTION
comm_channel.hpp: fix construction of UnixEp in createEp(), convert std::string_view to std::string in args when construct UnixEp
CMakeLists.txt: add link of Threads::Threads for ut